### PR TITLE
chore(hashicorp/google): 5.4.0 -> 5.5.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -13,7 +13,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = "5.4.0"
+      version = "5.5.0"
     }
 
     http = {


### PR DESCRIPTION
no changes affect our implementation: https://github.com/hashicorp/terraform-provider-google/releases/tag/v5.5.0