### PR TITLE
fix: kubernetes provider version 2.33.0 -> 2.24.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -58,7 +58,7 @@ terraform {
 
     kubernetes = {
       source = "hashicorp/kubernetes"
-      version = "2.33.0"
+      version = "2.24.0"
     }
     
   }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Rolled back the Kubernetes provider version in the Terraform configuration from 2.33.0 to 2.24.0 to address compatibility or stability issues.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>versions.tf</strong><dd><code>Rollback Kubernetes provider version in Terraform configuration</code></dd></summary>
<hr>

versions.tf

- Rolled back the Kubernetes provider version from 2.33.0 to 2.24.0.



</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-provider-versions/pull/352/files#diff-dfd5848fa77a04d0343891fe859286cc210473d10f0e62c7f99f0d5ecf1a9927">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information