### PR TITLE
fix: Downgrade Kubernetes provider version to 2.24.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -43,7 +43,7 @@ terraform {
 
     kubernetes = {
       source = "hashicorp/kubernetes"
-      version = "2.38.0"
+      version = "2.24.0"
     }
     
   }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Downgrade Kubernetes provider from 2.38.0 to 2.24.0


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Kubernetes Provider 2.38.0"] -- "downgrade" --> B["Kubernetes Provider 2.24.0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>versions.tf</strong><dd><code>Kubernetes provider version downgrade</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

versions.tf

- Downgraded Kubernetes provider version from 2.38.0 to 2.24.0


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-provider-versions/pull/466/files#diff-dfd5848fa77a04d0343891fe859286cc210473d10f0e62c7f99f0d5ecf1a9927">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

